### PR TITLE
fix Failed to execute 'setAttribute' on 'Element'

### DIFF
--- a/src/Captcha.php
+++ b/src/Captcha.php
@@ -143,7 +143,7 @@ class Captcha extends InputWidget
 
         $options = [
             'refreshUrl' => Url::toRoute($route),
-            'hashKey' => 'yiiCaptcha/' . trim($route[0], '/'),
+            'hashKey' => 'yii-captcha-' . str_replace(trim($route[0], '/'), '/', '-'),
         ];
 
         return $options;


### PR DESCRIPTION
fix Failed to execute 'setAttribute' on 'Element': 'data-yiiCaptcha/site/captcha' is not a valid attribute name.
